### PR TITLE
datum gecorrigeerd

### DIFF
--- a/artikelen/ringfestival.html
+++ b/artikelen/ringfestival.html
@@ -7,7 +7,7 @@
   <body>
     <h1><a href="../index.html">Sharting</a></h1>
     <h2>Kaartjes voor ringfestival te koop</h2>
-    <div class="subtitle">21 juni 2025</div>
+    <div class="subtitle">21 mei 2025</div>
     <p>
       Ik heb 345 kaartjes voor het ringfestival te koop. €80 per stuk. Je kan het overmaken op mijn bitcoin wallet 26f9219134145e108c756204e549ae937012caa4.
 </p>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     </tr>
     <tr>
       <th><a href="artikelen/ringfestival.html">Ringfestival kaartjes te koop</a></th>
-      <th>21 juni 2025</th>
+      <th>21 mei 2025</th>
     </tr>
       </tbody>
   </table>


### PR DESCRIPTION
Wat een amateuristische fout. Ik had toch meer verwacht van een nieuwsnetwerk van dit kadaver. Waar is het oude [sharting.nl](sharting.nl) gebleven? Weg is de toonaangevende onderzoeksjournalistiek, verdwenen zijn de messcherpe analyses van onze contemporaine samenleving en bovenal is de heer Shart nu ook zijn laatste sprankje integriteit kwijt.